### PR TITLE
Add __WARN__ and __DIE__ to Perlvar::is_var

### DIFF
--- a/lib/App/perlfind/Plugin/Perlvar.pm
+++ b/lib/App/perlfind/Plugin/Perlvar.pm
@@ -245,7 +245,7 @@ my %is_var = (
           );
 
 # find __WARN__, WARN, INT etc. as %SIG.
-$is_var{$_} = '%SIG' for qw(WARN DIE), keys %SIG;
+$is_var{$_} = '%SIG' for qw(WARN __WARN__ DIE __DIE__), keys %SIG;
 
 App::perlfind->add_trigger(
     'matches.add' => sub {

--- a/t/find_matches.t
+++ b/t/find_matches.t
@@ -33,8 +33,17 @@ my %expect = (
     '_'      => [ '$_'     => qw(perlvar) ],
     'lib/App/perlfind.pm' => [ 'lib/App/perlfind.pm' ],
 );
+my %min_version = (
+    # Some symbols are not defined in all perl versions
+    '__PACKAGE__' => 5.016,
+);
 for my $query (sort keys %expect) {
-    test_find_matches($query, $expect{$query});
+SKIP: {
+        my $req = $min_version{$query};
+        skip "find_matches($query) requires perl $min_version{$query}", 1
+            if $req && $] < $req;
+        test_find_matches($query, $expect{$query});
+    }
 }
 done_testing;
 


### PR DESCRIPTION
Fixes test failures in t/find_matches.t

```
#   Failed test 'find_matches(__WARN__) searches for [__WARN__]...'
#   at t/find_matches.t line 45.
#          got: '__WARN__'
#     expected: '%SIG'

#   Failed test '... in perlvar'
#   at t/find_matches.t line 47.
# +----+-----+----+-------------+
# | Elt|Got  | Elt|Expected     |
# +----+-----+----+-------------+
# *   0|[]   *   0|[            *
# |    |     *   1|  'perlvar'  *
# |    |     *   2|]            *
# +----+-----+----+-------------+
# Looks like you failed 2 tests of 48.
```

%SIG doesn't contain any of the DIE or WARN variations, so it seems these all need to be added manually to %is_var.